### PR TITLE
Slight changes to `README.md` to reflect latest changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Forked from [circle-makotom/circle-advanced-setup-workflow](https://github.com/circle-makotom/circle-advanced-setup-workflow).
 
-[Makoto Mizukami](https://github.com/circle-makotom) gets all of the credit for the CircleCI® configs, and the entire concept of this repo.
+[Makoto Mizukami](https://github.com/circle-makotom) gets all of the credit for the [CircleCI®](https://circleci.com/docs/2.0/first-steps/) configs, and the entire concept of this repo.
 
 Now, the module directories are organized by language, like `js/` and `php/`, and adding very basic examples in them.
 
@@ -14,7 +14,7 @@ For example, if there's no `.php` file in the diff, the PHPUnit tests won't run.
 
 And if the PR only changes the `README.md`, no dynamic jobs will run.
 
-This repository demonstrates an advanced use case of the [setup workflow](https://circleci.com/blog/introducing-dynamic-config-via-setup-workflows/) feature on [CircleCI](https://circleci.com/docs/2.0/first-steps/).
+This repository demonstrates an advanced use case of the [setup workflow](https://circleci.com/blog/introducing-dynamic-config-via-setup-workflows/) feature on CircleCI.
 
 ## How does it work?
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ The great thing about Makoto's idea here is that jobs only run when there's a ce
 
 For example, if there's no `.php` file in the diff, the PHPUnit tests won't run.
 
-And if the PR only changes the `README.md`, no dynamic jobs will run.
+If there's no `.js` file in the diff, the Jest tests won't run.
+
+And if the PR only changes the `README.md`, no dynamic job will run, only the job `Create dynamic jobs`.
 
 This repository demonstrates an advanced use case of the [setup workflow](https://circleci.com/blog/introducing-dynamic-config-via-setup-workflows/) feature on CircleCI.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Forked from [circle-makotom/circle-advanced-setup-workflow](https://github.com/c
 
 [Makoto Mizukami](https://github.com/circle-makotom) gets all of the credit for the [CircleCI®](https://circleci.com/docs/2.0/first-steps/) configs, and the entire concept of this repo.
 
-Now, the module directories are organized by language, like `js/` and `php/`, and adding very basic examples in them.
+As a slight change, the module directories are organized by language, like `js/` and `php/`.
 
 This is similar to how WordPress plugins can look.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Forked from [circle-makotom/circle-advanced-setup-workflow](https://github.com/c
 
 [Makoto Mizukami](https://github.com/circle-makotom) gets all of the credit for the CircleCI® configs, and the entire concept of this repo.
 
-The main change is making the module directories organized by language, like `js/` and `php/`, and adding very basic examples in them.
+Now, the module directories are organized by language, like `js/` and `php/`, and adding very basic examples in them.
 
 This is similar to how WordPress plugins can look.
 
@@ -14,7 +14,7 @@ For example, if there's no `.php` file in the diff, the PHPUnit tests won't run.
 
 And if the PR only changes the `README.md`, no dynamic jobs will run.
 
-This repository demonstrates an advanced use case of setup workflow feature on CircleCI. For instance, it implements both path filtering and config splitting.
+This repository demonstrates an advanced use case of the [setup workflow](https://circleci.com/blog/introducing-dynamic-config-via-setup-workflows/) feature on [CircleCI](https://circleci.com/docs/2.0/first-steps/).
 
 ## How does it work?
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ As a slight change, the module directories are organized by language, like `js/`
 
 This is similar to how WordPress plugins can look.
 
+## Only runs jobs that are needed
+
 The great thing about Makoto's idea here is that jobs only run when there's a certain diff.
 
 For example, if there's no `.php` file in the diff, the PHPUnit tests won't run.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For example, if there's no `.php` file in the diff, the PHPUnit tests won't run.
 
 If there's no `.js` file in the diff, the Jest tests won't run.
 
-And if the PR only changes the `README.md`, no dynamic job will run, only the job `Create dynamic jobs`.
+And if the PR only changes `README.md`, no dynamic job will run, only the job `Create dynamic jobs`.
 
 This repository demonstrates an advanced use case of the [setup workflow](https://circleci.com/blog/introducing-dynamic-config-via-setup-workflows/) feature on CircleCI.
 

--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ This repository demonstrates an advanced use case of the [setup workflow](https:
 1. CircleCI triggers the setup job `Create dynamic jobs`, defined in [.circleci/config.yml](.circleci/config.yml).
 2. That job finds which file types were changed in the current branch versus the [main](https://github.com/kienstra/circle-advanced-setup-workflow/tree/main) branch.
 3. It emits those changed file types as pipeline parameters.
-4. [.circleci/workflow.yml](.circleci/workflow.yml) receives those pipeline parameters.
+4. [.circleci/workflow.yml](.circleci/workflow.yml) receives those pipeline parameters, like `<< pipeline.parameters.run-php >>`.
 5. Those determine whether to run the jobs for [php/](php/), [js/](js/), and [e2e/](e2e/).


### PR DESCRIPTION
* Remove the sentence about 'config splitting,' as that's not really what this does anymore
* Add a subheading
* Add an example of a pipeline parameter